### PR TITLE
Patch for mito wierdness

### DIFF
--- a/cerebra/find_aa_mutations.py
+++ b/cerebra/find_aa_mutations.py
@@ -2,6 +2,7 @@ import re
 from collections import defaultdict
 from pathlib import Path
 import multiprocessing
+from os import system 
 
 import click
 import hgvs.parser
@@ -18,7 +19,8 @@ from .utils import GenomePosition, GenomeIntervalTree, GFFFeature, \
 
 
 class AminoAcidMutationFinder():
-    def __init__(self, cosmic_df, annotation_df, genome_faidx, cov_bool, lock):
+    def __init__(self, cosmic_df, annotation_df, genome_faidx, cov_bool):
+
         if cosmic_df is not None:
             filtered_cosmic_df = self._make_filtered_cosmic_df(cosmic_df)
 
@@ -34,7 +36,7 @@ class AminoAcidMutationFinder():
             (GFFFeature(row) for _, row in annotation_df.iterrows()))
 
         self._protein_variant_predictor = ProteinVariantPredictor(
-            self._annotation_genome_tree, genome_faidx, lock)
+            self._annotation_genome_tree, genome_faidx)
 
         self._coverage_bool = cov_bool
 
@@ -264,8 +266,6 @@ def find_aa_mutations(num_processes, cosmicdb_path, annotation_path,
     """ report amino-acid level SNPs and indels in each sample, and
         associated coverage """
 
-    plock = multiprocessing.Lock()
-
     print("Beginning setup (this may take several minutes!)")
 
     if cosmicdb_path:
@@ -282,7 +282,8 @@ def find_aa_mutations(num_processes, cosmicdb_path, annotation_path,
 
     print("Building genome trees...")
     aa_mutation_finder = AminoAcidMutationFinder(cosmic_df, annotation_df,
-                                                 genome_faidx, cov_bool, plock)
+                                                genome_faidx, cov_bool)
+
     print("Setup complete.")
 
     print("Finding mutations...")

--- a/cerebra/protein_variant_predictor.py
+++ b/cerebra/protein_variant_predictor.py
@@ -46,7 +46,6 @@ class ProteinVariantPredictor():
     # which is is already being emulated (to an extent) below.
     def __init__(self, annotation_genome_tree, genome_faidx):
         self.genome_fasta = genome_faidx
-        self.genome_fasta_mito = genome_faidx["chrM"][:]
 
         transcript_feats_dict = defaultdict(lambda: defaultdict(list))
         for feature in annotation_genome_tree.records:
@@ -121,6 +120,11 @@ class ProteinVariantPredictor():
         self.tree = GenomeIntervalTree(lambda record: record.feat.pos,
                                        cds_records)
 
+        if 'chrM' in self.genome_fasta.keys():
+            self.genome_fasta_mito = genome_faidx["chrM"][:]
+        else:
+            self.genome_fasta_mito = None
+
     @classmethod
     def _merged_and_sorted_intersecting_intervals(cls, intervals):
         current_interval = None
@@ -161,17 +165,19 @@ class ProteinVariantPredictor():
     def predict_for_vcf_record(self, vcf_record):
 
         def check_str(s):
-            ''' check a string to see if it has non-sequence 
-                characters '''
+            ''' check a string to see if it has non-sequence characters '''
             match = re.match("^[AGCTN]*$", s)
             return match is not None
 
 
         def handle_mito(_tx_pos):
             ''' handles this chrM wierdness '''
-            mito_seq = Seq(self.genome_fasta_mito.seq[_tx_pos.start:_tx_pos.end], 
+            mito_seq = None
+            if self.genome_fasta_mito:
+                mito_seq = Seq(self.genome_fasta_mito.seq[_tx_pos.start:_tx_pos.end], 
                             alphabet=Alphabet.generic_dna)
             return mito_seq
+
 
         variant_results = []
         record_pos = GenomePosition.from_vcf_record_pos(vcf_record)
@@ -204,11 +210,13 @@ class ProteinVariantPredictor():
                                  [tx_pos.start:tx_pos.end].seq,
                                  alphabet=Alphabet.generic_dna)
 
-                if not check_str(str(ref_tx_seq)):
+                if not check_str(str(ref_tx_seq)): # non-DNA seq chars
                     if tx_pos.chrom == 'M':
                         ref_tx_seq = handle_mito(tx_pos)
-                    else:
-                        continue # dont know how to handle this, skip iter
+                        if not ref_tx_seq:
+                            continue
+                    else:   # this shouldn't happen; skip iter
+                        continue 
 
                 ref_slice = ref_pos.slice_within(tx_pos)
 

--- a/cerebra/protein_variant_predictor.py
+++ b/cerebra/protein_variant_predictor.py
@@ -1,5 +1,6 @@
 from collections import defaultdict, namedtuple
 from itertools import tee
+import re 
 
 from Bio import Alphabet
 from Bio.Seq import Seq  # need to clean this up
@@ -43,9 +44,9 @@ class ProteinVariantPredictor():
     # TODO: Now I think it would be nice if this was written to use GFF3
     # instead of GTF because of the hierarchic feature structure GFF3 provides,
     # which is is already being emulated (to an extent) below.
-    def __init__(self, annotation_genome_tree, genome_faidx, lock):
+    def __init__(self, annotation_genome_tree, genome_faidx):
         self.genome_fasta = genome_faidx
-        self._lock = lock
+        self.genome_fasta_mito = genome_faidx["chrM"][:]
 
         transcript_feats_dict = defaultdict(lambda: defaultdict(list))
         for feature in annotation_genome_tree.records:
@@ -158,8 +159,21 @@ class ProteinVariantPredictor():
         return spliced_seq
 
     def predict_for_vcf_record(self, vcf_record):
-        variant_results = []
 
+        def check_str(s):
+            ''' check a string to see if it has non-sequence 
+                characters '''
+            match = re.match("^[AGCTN]*$", s)
+            return match is not None
+
+
+        def handle_mito(_tx_pos):
+            ''' handles this chrM wierdness '''
+            mito_seq = Seq(self.genome_fasta_mito.seq[_tx_pos.start:_tx_pos.end], 
+                            alphabet=Alphabet.generic_dna)
+            return mito_seq
+
+        variant_results = []
         record_pos = GenomePosition.from_vcf_record_pos(vcf_record)
 
         ref = vcf_record.REF
@@ -186,11 +200,15 @@ class ProteinVariantPredictor():
                     min(0, ref_pos.start - tx_pos.start),
                     max(0, ref_pos.end - tx_pos.end))
 
-                self._lock.acquire()
                 ref_tx_seq = Seq(self.genome_fasta["chr" + tx_pos.chrom]
                                  [tx_pos.start:tx_pos.end].seq,
                                  alphabet=Alphabet.generic_dna)
-                self._lock.release()
+
+                if not check_str(str(ref_tx_seq)):
+                    if tx_pos.chrom == 'M':
+                        ref_tx_seq = handle_mito(tx_pos)
+                    else:
+                        continue # dont know how to handle this, skip iter
 
                 ref_slice = ref_pos.slice_within(tx_pos)
 


### PR DESCRIPTION
ok i think this finally resolves issue #47 
i added two sub methods to handle the case where multiple threads try to read _chrM_ from the reference genome at the same time and mess everything up. 

`check_str()` checks the _ref_tx_seq_ to make sure it contains only DNA sequence chars

`handle_mito()` queries a seperate mitochondrial genome object for the exception case where `check_str()` fails and the query interval is on the mitochondrial chromosome. 

if the problematic _ref_tx_seq_ str DOES NOT come from chrM, then we handle gracefully by skipping that iteration of the loop altogether. this is not quiet idea as we are potentially throwing away a transcript ID, however, I have yet to see this case occur and think it probably doesnt ever. 

ive tested this pretty extensively on two different vcf datasets, both on my laptop and on a local server

it also gracefully handles the case where the users genome does not include __chrM__